### PR TITLE
sftpConnect always tries to use keyfile / typo: password instead of passwd

### DIFF
--- a/lib/SenderFTP.py
+++ b/lib/SenderFTP.py
@@ -299,13 +299,13 @@ class SenderFTP(object):
                 if self.client.port == '' or self.client.port == None : 
                    self.client.port = 22
             
-                if hasattr(self.client, 'ssh_keyfile') :
-                   self.client.password = None
+                if self.client.ssh_keyfile is not None :
+                   self.client.passwd = None
                    self.ssh.connect( self.client.host, self.client.port, self.client.user, \
-                         self.client.password, pkey=None , key_filename=self.client.ssh_keyfile )
+                         self.client.passwd, pkey=None , key_filename=self.client.ssh_keyfile )
                 else:
                    self.ssh.connect( self.client.host, self.client.port, self.client.user, \
-                         self.client.password )
+                         self.client.passwd )
 
                 self.sftp = self.ssh.open_sftp()
                 # WORKAROUND without going to '.' originalDir was None


### PR DESCRIPTION
Pardon if I get the terminology incorrect, my first time troubleshooting Python code.

DMS still uses Sundew to push a small number of products via ftp/sftp.  Some old Sundew clients broke when migrating from Ubuntu 12.04 to Ubuntu 18.04.  The `sftpConnect()` method in SenderFTP.py always tries to connect using an SSH key. The `hasattr()` test is always true because the `ssh_keyfile` attribute(?) is always initialized to at least None.  Also, the attribute for the client password should be `passwd`, not `password`.